### PR TITLE
Feature : アカウントの削除を論理か物理かをロールで制御できるように

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -8023,6 +8023,10 @@ export interface Locale extends ILocale {
              */
             "canEditNote": string;
             /**
+             * 完全なアカウントの削除
+             */
+            "canPurgeAccount": string;
+            /**
              * 予約投稿の最大数
              */
             "scheduleNoteMax": string;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2076,6 +2076,7 @@ _role:
     btlAvailable: "バブルタイムラインの閲覧"
     canPublicNote: "パブリック投稿の許可"
     canEditNote: "ノートの編集"
+    canPurgeAccount: "完全なアカウントの削除"
     scheduleNoteMax: "予約投稿の最大数"
     mentionMax: "ノート内の最大メンション数"
     canInvite: "サーバー招待コードの発行"

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -2054,6 +2054,7 @@ _role:
     btlAvailable: "버블 타임라인 보이기"
     canPublicNote: "공개 노트 허용"
     canEditNote: "노트 편집 허용"
+    canPurgeAccount: "완전한 계정 삭제 허용"
     scheduleNoteMax: "게시를 예약한 노트의 최대 수"
     mentionMax: "노트에서 언급할 수 있는 멘션 수"
     canInvite: "서버 초대 코드 발행"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cherrypick",
-	"version": "4.15.0-misaki.4",
+	"version": "4.15.0-misaki.5",
 	"basedMisskeyVersion": "2025.2.0",
 	"codename": "nasubi",
 	"repository": {
@@ -57,21 +57,23 @@
 	},
 	"dependencies": {
 		"cssnano": "6.1.2",
+		"esbuild": "0.24.0",
 		"execa": "8.0.1",
 		"fast-glob": "3.3.2",
+		"glob": "11.0.0",
 		"ignore-walk": "6.0.5",
 		"js-yaml": "4.1.0",
 		"postcss": "8.4.49",
 		"tar": "6.2.1",
 		"terser": "5.36.0",
-		"typescript": "5.6.3",
-		"esbuild": "0.24.0",
-		"glob": "11.0.0"
+		"typescript": "5.6.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.3",
 		"@misskey-dev/eslint-plugin": "2.0.3",
+		"@types/matter-js": "0.19.7",
 		"@types/node": "22.9.0",
+		"@types/seedrandom": "3.0.8",
 		"@typescript-eslint/eslint-plugin": "7.17.0",
 		"@typescript-eslint/parser": "7.17.0",
 		"cross-env": "7.0.3",
@@ -79,6 +81,7 @@
 		"eslint": "9.14.0",
 		"globals": "15.12.0",
 		"ncp": "2.0.0",
+		"nodemon": "3.1.7",
 		"start-server-and-test": "2.0.8"
 	},
 	"optionalDependencies": {

--- a/packages/backend/src/core/DeleteAccountService.ts
+++ b/packages/backend/src/core/DeleteAccountService.ts
@@ -5,6 +5,8 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import { Not, IsNull } from 'typeorm';
+import type Logger from '@/logger.js';
+import { RoleService } from '@/core/RoleService.js';
 import type { FollowingsRepository, MiUser, UsersRepository } from '@/models/_.js';
 import { QueueService } from '@/core/QueueService.js';
 import { DI } from '@/di-symbols.js';
@@ -13,9 +15,12 @@ import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
+import { LoggerService } from '@/core/LoggerService.js';
 
 @Injectable()
 export class DeleteAccountService {
+	public logger: Logger;
+
 	constructor(
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
@@ -23,19 +28,22 @@ export class DeleteAccountService {
 		@Inject(DI.followingsRepository)
 		private followingsRepository: FollowingsRepository,
 
+		private roleService: RoleService,
+		private userSuspendService: UserSuspendService,
+		private loggerService: LoggerService,
 		private userEntityService: UserEntityService,
 		private apRendererService: ApRendererService,
 		private queueService: QueueService,
 		private globalEventService: GlobalEventService,
 		private moderationLogService: ModerationLogService,
 	) {
+		this.logger = this.loggerService.getLogger('delete-account');
 	}
 
 	@bindThis
-	public async deleteAccount(user: {
-		id: string;
-		host: string | null;
-	}, moderator?: MiUser): Promise<void> {
+	public async deleteAccount(user: MiUser, soft: boolean, me: MiUser | null, moderator: MiUser | null = null): Promise<void> {
+		this.logger.warn(`Delete account requested by ${me ? me.id : 'remote'} for ${user.id} (soft: ${soft})`);
+
 		const _user = await this.usersRepository.findOneByOrFail({ id: user.id });
 		if (_user.isRoot) throw new Error('cannot delete a root account');
 
@@ -73,7 +81,8 @@ export class DeleteAccountService {
 			}
 
 			this.queueService.createDeleteAccountJob(user, {
-				soft: false,
+				force: me ? await this.roleService.isModerator(me) : false,
+				soft: soft,
 			});
 		} else {
 			// リモートユーザーの削除は、完全にDBから物理削除してしまうと再度連合してきてアカウントが復活する可能性があるため、soft指定する
@@ -87,5 +96,17 @@ export class DeleteAccountService {
 		});
 
 		this.globalEventService.publishInternalEvent('userChangeDeletedState', { id: user.id, isDeleted: true });
+	}
+
+	@bindThis
+	public async deleteAllDriveFiles(user: MiUser, me: MiUser | null): Promise<void> {
+		this.logger.warn(`Delete all drive files requested by ${me ? me.id : 'remote'} for ${user.id}`);
+
+		await this.usersRepository.findOneByOrFail({ id: user.id });
+
+		this.queueService.createDeleteAccountJob(user, {
+			force: me ? await this.roleService.isModerator(me) : false,
+			onlyFiles: true,
+		});
 	}
 }

--- a/packages/backend/src/core/DeleteAccountService.ts
+++ b/packages/backend/src/core/DeleteAccountService.ts
@@ -9,6 +9,7 @@ import type Logger from '@/logger.js';
 import { RoleService } from '@/core/RoleService.js';
 import type { FollowingsRepository, MiUser, UsersRepository } from '@/models/_.js';
 import { QueueService } from '@/core/QueueService.js';
+import { UserSuspendService } from '@/core/UserSuspendService.js';
 import { DI } from '@/di-symbols.js';
 import { bindThis } from '@/decorators.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -389,10 +389,13 @@ export class QueueService {
 	}
 
 	@bindThis
-	public createDeleteAccountJob(user: ThinUser, opts: { soft?: boolean; } = {}) {
+
+	public createDeleteAccountJob(user: ThinUser, opts: { soft?: boolean, force?: boolean, onlyFiles?: boolean } = {}) {
 		return this.dbQueue.add('deleteAccount', {
 			user: { id: user.id },
 			soft: opts.soft,
+			force: opts.force,
+			onlyFiles: opts.onlyFiles,
 		}, {
 			removeOnComplete: true,
 			removeOnFail: true,

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -37,6 +37,7 @@ export type RolePolicies = {
 	btlAvailable: boolean;
 	canPublicNote: boolean;
 	canEditNote: boolean;
+	canPurgeAccount: boolean;
 	scheduleNoteMax: number;
 	mentionLimit: number;
 	canInvite: boolean;
@@ -77,6 +78,7 @@ export const DEFAULT_POLICIES: RolePolicies = {
 	btlAvailable: false,
 	canPublicNote: true,
 	canEditNote: true,
+	canPurgeAccount: true,
 	scheduleNoteMax: 5,
 	mentionLimit: 20,
 	canInvite: false,
@@ -390,6 +392,7 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			btlAvailable: calc('btlAvailable', vs => vs.some(v => v === true)),
 			canPublicNote: calc('canPublicNote', vs => vs.some(v => v === true)),
 			canEditNote: calc('canEditNote', vs => vs.some(v => v === true)),
+			canPurgeAccount: calc('canPurgeAccount', vs => vs.some(v => v === true)),
 			scheduleNoteMax: calc('scheduleNoteMax', vs => Math.max(...vs)),
 			mentionLimit: calc('mentionLimit', vs => Math.max(...vs)),
 			canInvite: calc('canInvite', vs => vs.some(v => v === true)),

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -555,7 +555,8 @@ export class ApInboxService {
 			return 'skip: already deleted';
 		}
 
-		const job = await this.queueService.createDeleteAccountJob(actor);
+		// リモートから消されたということなので、物理削除する
+		const job = await this.queueService.createDeleteAccountJob(actor, { force: true, soft: false });
 
 		await this.usersRepository.update(actor.id, {
 			isDeleted: true,

--- a/packages/backend/src/models/json-schema/role.ts
+++ b/packages/backend/src/models/json-schema/role.ts
@@ -304,6 +304,10 @@ export const packedRolePoliciesSchema = {
 			type: 'boolean',
 			optional: false, nullable: false,
 		},
+		canPurgeAccount: {
+			type: 'boolean',
+			optional: false, nullable: false,
+		},
 		scheduleNoteMax: {
 			type: 'integer',
 			optional: false, nullable: false,

--- a/packages/backend/src/queue/processors/DeleteAccountProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeleteAccountProcessorService.ts
@@ -9,9 +9,11 @@ import { DI } from '@/di-symbols.js';
 import type { DriveFilesRepository, NotesRepository, UserProfilesRepository, UsersRepository } from '@/models/_.js';
 import type Logger from '@/logger.js';
 import { DriveService } from '@/core/DriveService.js';
+import type { MiUser } from '@/models/User.js';
 import type { MiDriveFile } from '@/models/DriveFile.js';
 import type { MiNote } from '@/models/Note.js';
 import { EmailService } from '@/core/EmailService.js';
+import { RoleService } from '@/core/RoleService.js';
 import { bindThis } from '@/decorators.js';
 import { SearchService } from '@/core/SearchService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
@@ -39,80 +41,74 @@ export class DeleteAccountProcessorService {
 		private userEntityService: UserEntityService,
 		private driveService: DriveService,
 		private emailService: EmailService,
+		private roleService: RoleService,
 		private queueLoggerService: QueueLoggerService,
 		private searchService: SearchService,
 	) {
 		this.logger = this.queueLoggerService.logger.createSubLogger('delete-account');
 	}
 
+	private async deleteNotes(user: MiUser) {
+		while (true) {
+			const notes = await this.notesRepository.find({
+				where: {
+					userId: user.id,
+				},
+				take: 100,
+			});
+
+			if (notes.length === 0) {
+				break;
+			}
+
+			await this.notesRepository.delete(notes.map(note => note.id));
+
+			for (const note of notes) {
+				await this.searchService.unindexNote(note);
+			}
+		}
+
+		this.logger.succ('All of notes deleted');
+	}
+
+	private async deleteFiles(user: MiUser) {
+		while (true) {
+			const files = await this.driveFilesRepository.find({
+				where: {
+					userId: user.id,
+				},
+				take: 10,
+			});
+
+			if (files.length === 0) {
+				break;
+			}
+
+			for (const file of files) {
+				await this.driveService.deleteFileSync(file);
+			}
+		}
+
+		this.logger.succ('All of files deleted');
+	}
+
 	@bindThis
 	public async process(job: Bull.Job<DbUserDeleteJobData>): Promise<string | void> {
-		this.logger.info(`Deleting account of ${job.data.user.id} ...`);
-
+		this.logger.info(`Deleting account of ${job.data.user.id} ...`, { userDeleteJobData: job.data });
 		const user = await this.usersRepository.findOneBy({ id: job.data.user.id });
 		const isRemote = user ? this.userEntityService.isRemoteUser(user) : false;
 		if (user == null) {
 			return;
 		}
+		const { /*canDeleteContent,*/ canPurgeAccount } = !job.data.force
+			? await this.roleService.getUserPolicies(user.id)
+			: { /*canDeleteContent: true,*/ canPurgeAccount: true };
 
-		{ // Delete notes
-			let cursor: MiNote['id'] | null = null;
+		if (job.data.onlyFiles) {
+			//if (!canDeleteContent) return 'Permission denied';
 
-			while (true) {
-				const notes = await this.notesRepository.find({
-					where: {
-						userId: user.id,
-						...(cursor ? { id: MoreThan(cursor) } : {}),
-					},
-					take: 100,
-					order: {
-						id: 1,
-					},
-				}) as MiNote[];
-
-				if (notes.length === 0) {
-					break;
-				}
-
-				cursor = notes.at(-1)?.id ?? null;
-
-				await this.notesRepository.delete(notes.map(note => note.id));
-
-				for (const note of notes) {
-					await this.searchService.unindexNote(note);
-				}
-			}
-
-			this.logger.succ(`All of notes deleted: ${job.data.user.id}`);
-		}
-
-		{ // Delete files
-			let cursor: MiDriveFile['id'] | null = null;
-
-			while (true) {
-				const files = await this.driveFilesRepository.find({
-					where: {
-						userId: user.id,
-						...(cursor ? { id: MoreThan(cursor) } : {}),
-					},
-					take: 10,
-					order: {
-						id: 1,
-					},
-				}) as MiDriveFile[];
-
-				if (files.length === 0) {
-					break;
-				}
-
-				cursor = files.at(-1)?.id ?? null;
-
-				for (const file of files) {
-					await this.driveService.deleteFileSync(file, undefined, isRemote);
-				}
-			}
-
-			this.logger.succ(`All of files deleted: ${job.data.user.id}`);
+			await this.deleteFiles(user);
+			return 'Files deleted';
 		}
 
 		{ // Send email notification
@@ -125,8 +121,12 @@ export class DeleteAccountProcessorService {
 		}
 
 		// soft指定されている場合は物理削除しない
-		if (job.data.soft) {
-		// nop
+		if (!(/*canDeleteContent && */canPurgeAccount) || job.data.soft) {
+			await this.usersRepository.update(user.id, {
+				token: null,
+				isSuspended: true,
+				isDeleted: true,
+			});
 		} else {
 			await this.usersRepository.delete(job.data.user.id);
 		}

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -82,6 +82,8 @@ export type DBExportAntennasData = {
 export type DbUserDeleteJobData = {
 	user: ThinUser;
 	soft?: boolean;
+	force?: boolean;
+	onlyFiles?: boolean;
 };
 
 export type DbUserTruncateJobData = {

--- a/packages/backend/src/server/api/SigninApiService.ts
+++ b/packages/backend/src/server/api/SigninApiService.ts
@@ -25,6 +25,7 @@ import { WebAuthnService } from '@/core/WebAuthnService.js';
 import { UserAuthService } from '@/core/UserAuthService.js';
 import { CaptchaService } from '@/core/CaptchaService.js';
 import { FastifyReplyError } from '@/misc/fastify-reply-error.js';
+import { LoggerService } from '@/core/LoggerService.js';
 import { RateLimiterService } from './RateLimiterService.js';
 import { SigninService } from './SigninService.js';
 import type { AuthenticationResponseJSON } from '@simplewebauthn/types';
@@ -56,6 +57,7 @@ export class SigninApiService {
 		private signinService: SigninService,
 		private userAuthService: UserAuthService,
 		private webAuthnService: WebAuthnService,
+		private loggerService: LoggerService,
 		private captchaService: CaptchaService,
 	) {
 	}
@@ -77,6 +79,7 @@ export class SigninApiService {
 		}>,
 		reply: FastifyReply,
 	) {
+		const logger = this.loggerService.getLogger('api:signin');
 		reply.header('Access-Control-Allow-Origin', this.config.url);
 		reply.header('Access-Control-Allow-Credentials', 'true');
 
@@ -121,6 +124,13 @@ export class SigninApiService {
 		}) as MiLocalUser;
 
 		if (user == null) {
+			return error(404, {
+				id: '6cc579cc-885d-43d8-95c2-b8c7fc963280',
+			});
+		}
+
+		if (user.isDeleted && user.isSuspended) {
+			logger.error('No such user. (logical deletion)');
 			return error(404, {
 				id: '6cc579cc-885d-43d8-95c2-b8c7fc963280',
 			});

--- a/packages/backend/src/server/api/endpoints/admin/accounts/delete.ts
+++ b/packages/backend/src/server/api/endpoints/admin/accounts/delete.ts
@@ -7,9 +7,11 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import type { UsersRepository } from '@/models/_.js';
 import { QueueService } from '@/core/QueueService.js';
+import { RoleService } from '@/core/RoleService.js';
 import { DI } from '@/di-symbols.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { DeleteAccountService } from '@/core/DeleteAccountService.js';
+import { ApiError } from '@/server/api/error.js';
 
 export const meta = {
 	tags: ['admin'],
@@ -17,12 +19,27 @@ export const meta = {
 	requireCredential: true,
 	requireAdmin: true,
 	kind: 'write:admin:account',
+
+	errors: {
+		userNotFound: {
+			message: 'User not found.',
+			code: 'USER_NOT_FOUND',
+			id: '6c45276a-525e-46b0-892f-17a5036258bf',
+		},
+
+		cannotDeleteModerator: {
+			message: 'Cannot delete a moderator.',
+			code: 'CANNOT_DELETE_MODERATOR',
+			id: 'd195c621-f21a-4c2f-a634-484c2a616311',
+		},
+	},
 } as const;
 
 export const paramDef = {
 	type: 'object',
 	properties: {
 		userId: { type: 'string', format: 'misskey:id' },
+		soft: { type: 'boolean', default: true, description: 'Since deletion by an administrator is a moderation action, the default is to soft delete.' },
 	},
 	required: ['userId'],
 } as const;
@@ -33,20 +50,16 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
 
-		private deleteAccoountService: DeleteAccountService,
+		private roleService: RoleService,
+		private deleteAccountService: DeleteAccountService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const user = await this.usersRepository.findOneBy({ id: ps.userId });
 
-			if (user == null) {
-				throw new Error('user not found');
-			}
+			if (user == null) throw new ApiError(meta.errors.userNotFound);
+			if (await this.roleService.isModerator(user)) throw new ApiError(meta.errors.cannotDeleteModerator);
 
-			if (user.isRoot) {
-				throw new Error('cannot delete a root account');
-			}
-
-			await this.deleteAccoountService.deleteAccount(user, me);
+			await this.deleteAccountService.deleteAccount(user, true, me);
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/admin/show-user.ts
+++ b/packages/backend/src/server/api/endpoints/admin/show-user.ts
@@ -120,6 +120,14 @@ export const meta = {
 				type: 'boolean',
 				optional: false, nullable: false,
 			},
+			/*isLimited: {
+				type: 'boolean',
+				optional: false, nullable: false,
+			},*/
+			isDeleted: {
+				type: 'boolean',
+				optional: false, nullable: false,
+			},
 			isSuspended: {
 				type: 'boolean',
 				optional: false, nullable: false,
@@ -253,6 +261,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				notificationRecieveConfig: profile.notificationRecieveConfig,
 				isModerator: isModerator,
 				isSilenced: isSilenced,
+				//isLimited: user.isLimited,
+				isDeleted: user.isDeleted,
 				isSuspended: user.isSuspended,
 				isHibernated: user.isHibernated,
 				lastActiveDate: user.lastActiveDate ? user.lastActiveDate.toISOString() : null,

--- a/packages/backend/src/server/api/endpoints/admin/show-user.ts
+++ b/packages/backend/src/server/api/endpoints/admin/show-user.ts
@@ -261,7 +261,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				notificationRecieveConfig: profile.notificationRecieveConfig,
 				isModerator: isModerator,
 				isSilenced: isSilenced,
-				//isLimited: user.isLimited,
+				isLimited: false, //user.isLimited,
 				isDeleted: user.isDeleted,
 				isSuspended: user.isSuspended,
 				isHibernated: user.isHibernated,

--- a/packages/backend/test/e2e/users.ts
+++ b/packages/backend/test/e2e/users.ts
@@ -250,7 +250,7 @@ describe('ユーザー', () => {
 		await api('i/delete-account', { password: 'userDeletedBySelf' }, userDeletedBySelf);
 		userDeletedByAdmin = await signup({ username: 'userDeletedByAdmin' });
 		await post(userDeletedByAdmin, { text: 'test' });
-		await api('admin/delete-account', { userId: userDeletedByAdmin.id }, root);
+		await api('admin/accounts/delete', { userId: userDeletedByAdmin.id }, root);
 		userFollowingAlice = await signup({ username: 'userFollowingAlice' });
 		await post(userFollowingAlice, { text: 'test' });
 		await api('following/create', { userId: alice.id }, userFollowingAlice);

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -5423,6 +5423,7 @@ export type components = {
       gtlAvailable: boolean;
       ltlAvailable: boolean;
       canPublicNote: boolean;
+			canPurgeAccount: boolean;
       mentionLimit: number;
       canInvite: boolean;
       inviteLimit: number;

--- a/packages/frontend-shared/js/const.ts
+++ b/packages/frontend-shared/js/const.ts
@@ -81,6 +81,7 @@ export const ROLE_POLICIES = [
 	'ltlAvailable',
 	'btlAvailable',
 	'canPublicNote',
+	'canPurgeAccount',
 	'canEditNote',
 	'scheduleNoteMax',
 	'mentionLimit',

--- a/packages/frontend/.storybook/fakes.ts
+++ b/packages/frontend/.storybook/fakes.ts
@@ -255,6 +255,8 @@ export function userDetailed(id = 'someuserid', username = 'cherrypikist', host:
 		isModerator: false,
 		isMuted: false,
 		isSilenced: false,
+		isLimited: false,
+		isDeleted: false,
 		isSuspended: false,
 		lang: 'en',
 		location: 'Fediverse',

--- a/packages/frontend/src/pages/admin-user.vue
+++ b/packages/frontend/src/pages/admin-user.vue
@@ -628,6 +628,7 @@ definePageMetadata(() => ({
 			> .deleted {
 				color: var(--error);
 				border-color: var(--error);
+			}
 		}
 	}
 }

--- a/packages/frontend/src/pages/admin-user.vue
+++ b/packages/frontend/src/pages/admin-user.vue
@@ -15,9 +15,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<span class="name"><MkUserName class="name" :user="user"/></span>
 						<span class="sub"><span class="acct _monospace">@{{ acct(user) }}</span></span>
 						<span class="state">
-							<span v-if="suspended" class="suspended">Suspended</span>
-							<span v-if="silenced" class="silenced">Silenced</span>
+							<span v-if="admin" class="admin">Admin</span>
 							<span v-if="moderator" class="moderator">Moderator</span>
+							<span v-if="silenced" class="silenced">Silenced</span>
+							<span v-if="limited" class="limited">Limited</span>
+							<span v-if="suspended" class="suspended">Suspended</span>
+							<span v-if="deleted" class="deleted">Deleted</span>
 						</span>
 					</div>
 				</div>
@@ -251,6 +254,9 @@ const ap = ref<any>(null);
 const moderator = ref(false);
 const silenced = ref(false);
 const suspended = ref(false);
+const admin = ref(false);
+const limited = ref(false);
+const deleted = ref(false);
 const moderationNote = ref('');
 const filesPagination = {
 	endpoint: 'admin/drive/files' as const,
@@ -283,14 +289,18 @@ function createFetcher() {
 		user.value = _user;
 		info.value = _info;
 		ips.value = _ips;
+		admin.value = info.value.isAdmin;
+		deleted.value = info.value.isDeleted;
+		limited.value = info.value.isLimited;
 		moderator.value = info.value.isModerator;
 		silenced.value = info.value.isSilenced;
 		suspended.value = info.value.isSuspended;
 		moderationNote.value = info.value.moderationNote;
 
 		watch(moderationNote, async () => {
-			await misskeyApi('admin/update-user-note', { userId: user.value.id, text: moderationNote.value });
-			await refreshUser();
+			await misskeyApi('admin/update-user-note', {
+				userId: user.value.id, text: moderationNote.value,
+			}).then(refreshUser);
 		});
 	});
 }
@@ -300,8 +310,9 @@ function refreshUser() {
 }
 
 async function updateRemoteUser() {
-	await os.apiWithDialog('federation/update-remote-user', { userId: user.value.id });
-	refreshUser();
+	await os.apiWithDialog('federation/update-remote-user', {
+		userId: user.value.id,
+	}).then(refreshUser);
 }
 
 async function resetPassword() {
@@ -330,8 +341,9 @@ async function toggleSuspend(v) {
 	if (confirm.canceled) {
 		suspended.value = !v;
 	} else {
-		await misskeyApi(v ? 'admin/suspend-user' : 'admin/unsuspend-user', { userId: user.value.id });
-		await refreshUser();
+		await misskeyApi(v ? 'admin/suspend-user' : 'admin/unsuspend-user', {
+			userId: user.value.id,
+		}).then(refreshUser);
 	}
 }
 
@@ -341,17 +353,10 @@ async function unsetUserAvatar() {
 		text: i18n.ts.unsetUserAvatarConfirm,
 	});
 	if (confirm.canceled) return;
-	const process = async () => {
-		await misskeyApi('admin/unset-user-avatar', { userId: user.value.id });
-		os.success();
-	};
-	await process().catch(err => {
-		os.alert({
-			type: 'error',
-			text: err.toString(),
-		});
-	});
-	refreshUser();
+
+	await os.apiWithDialog('admin/unset-user-avatar', {
+		userId: user.value.id,
+	}).then(refreshUser);
 }
 
 async function unsetUserBanner() {
@@ -360,17 +365,10 @@ async function unsetUserBanner() {
 		text: i18n.ts.unsetUserBannerConfirm,
 	});
 	if (confirm.canceled) return;
-	const process = async () => {
-		await misskeyApi('admin/unset-user-banner', { userId: user.value.id });
-		os.success();
-	};
-	await process().catch(err => {
-		os.alert({
-			type: 'error',
-			text: err.toString(),
-		});
-	});
-	refreshUser();
+
+	await os.apiWithDialog('admin/unset-user-banner', {
+		userId: user.value.id,
+	}).then(refreshUser);
 }
 
 async function deleteAllFiles() {
@@ -379,16 +377,21 @@ async function deleteAllFiles() {
 		text: i18n.ts.deleteAllFilesConfirm,
 	});
 	if (confirm.canceled) return;
-	const process = async () => {
-		await misskeyApi('admin/delete-all-files-of-a-user', { userId: user.value.id });
-		os.success();
-	};
-	await process().catch(err => {
+	const typed = await os.inputText({
+		text: i18n.tsx.typeToConfirm({ x: user.value?.username }),
+	});
+	if (typed.canceled) return;
+
+	if (typed.result === user.value?.username) {
+		await os.apiWithDialog('admin/drive/delete-all-files-of-a-user', {
+			userId: user.value.id,
+		}).then(refreshUser);
+	} else {
 		os.alert({
 			type: 'error',
-			text: err.toString(),
+			text: 'input not match',
 		});
-	});
+	}
 	await refreshUser();
 }
 
@@ -405,9 +408,9 @@ async function deleteAccount() {
 	if (typed.canceled) return;
 
 	if (typed.result === user.value?.username) {
-		await os.apiWithDialog('admin/delete-account', {
+		await os.apiWithDialog('admin/accounts/delete', {
 			userId: user.value.id,
-		});
+		}).then(refreshUser);
 	} else {
 		os.alert({
 			type: 'error',
@@ -449,8 +452,9 @@ async function assignRole() {
 		: period === 'oneMonth' ? Date.now() + (1000 * 60 * 60 * 24 * 30)
 		: null;
 
-	await os.apiWithDialog('admin/roles/assign', { roleId, userId: user.value.id, expiresAt });
-	refreshUser();
+	await os.apiWithDialog('admin/roles/assign', {
+		roleId, userId: user.value.id, expiresAt,
+	}).then(refreshUser);
 }
 
 async function unassignRole(role, ev) {
@@ -459,8 +463,9 @@ async function unassignRole(role, ev) {
 		icon: 'ti ti-x',
 		danger: true,
 		action: async () => {
-			await os.apiWithDialog('admin/roles/unassign', { roleId: role.id, userId: user.value.id });
-			refreshUser();
+			await os.apiWithDialog('admin/roles/unassign', {
+				roleId: role.id, userId: user.value.id,
+			}).then(refreshUser);
 		},
 	}], ev.currentTarget ?? ev.target);
 }
@@ -582,12 +587,22 @@ definePageMetadata(() => ({
 				display: none;
 			}
 
-			> .suspended, > .silenced, > .moderator {
+			> .admin,
+			> .moderator,
+			> .silenced,
+			> .limited,
+			> .suspended,
+			> .deleted {
 				display: inline-block;
 				border: solid 1px;
 				border-radius: 6px;
 				padding: 2px 6px;
 				font-size: 85%;
+			}
+
+			> .admin {
+				color: var(--success);
+				border-color: var(--success);
 			}
 
 			> .suspended {
@@ -604,6 +619,15 @@ definePageMetadata(() => ({
 				color: var(--MI_THEME-success);
 				border-color: var(--MI_THEME-success);
 			}
+
+			> .limited {
+				color: var(--error);
+				border-color: var(--error);
+			}
+
+			> .deleted {
+				color: var(--error);
+				border-color: var(--error);
 		}
 	}
 }

--- a/packages/frontend/src/pages/admin/roles.editor.vue
+++ b/packages/frontend/src/pages/admin/roles.editor.vue
@@ -181,6 +181,26 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</div>
 			</MkFolder>
 
+			<MkFolder v-if="matchQuery([i18n.ts._role._options.canPurgeAccount, 'canPurgeAccount'])">
+				<template #label>{{ i18n.ts._role._options.canPurgeAccount }}</template>
+				<template #suffix>
+					<span v-if="role.policies.canPurgeAccount.useDefault" :class="$style.useDefaultLabel">{{ i18n.ts._role.useBaseValue }}</span>
+					<span v-else>{{ role.policies.canPurgeAccount.value ? i18n.ts.yes : i18n.ts.no }}</span>
+					<span :class="$style.priorityIndicator"><i :class="getPriorityIcon(role.policies.canPurgeAccount)"></i></span>
+				</template>
+				<div class="_gaps">
+					<MkSwitch v-model="role.policies.canPurgeAccount.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts._role.useBaseValue }}</template>
+					</MkSwitch>
+					<MkSwitch v-model="role.policies.canPurgeAccount.value" :disabled="role.policies.canPurgeAccount.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts.enable }}</template>
+					</MkSwitch>
+					<MkRange v-model="role.policies.canPurgeAccount.priority" :min="0" :max="2" :step="1" easing :textConverter="(v) => v === 0 ? i18n.ts._role._priority.low : v === 1 ? i18n.ts._role._priority.middle : v === 2 ? i18n.ts._role._priority.high : ''">
+						<template #label>{{ i18n.ts._role.priority }}</template>
+					</MkRange>
+				</div>
+			</MkFolder>
+
 			<MkFolder v-if="matchQuery([i18n.ts._role._options.canEditNote, 'canEditNote'])">
 				<template #label>{{ i18n.ts._role._options.canEditNote }}</template>
 				<template #suffix>

--- a/packages/frontend/src/pages/admin/roles.vue
+++ b/packages/frontend/src/pages/admin/roles.vue
@@ -63,6 +63,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 							</MkSwitch>
 						</MkFolder>
 
+						<MkFolder v-if="matchQuery([i18n.ts._role._options.canPurgeAccount, 'canPurgeAccount'])">
+							<template #label>{{ i18n.ts._role._options.canPurgeAccount }}</template>
+							<template #suffix>{{ policies.canPurgeAccount ? i18n.ts.yes : i18n.ts.no }}</template>
+							<MkSwitch v-model="policies.canPurgeAccount">
+								<template #label>{{ i18n.ts.enable }}</template>
+							</MkSwitch>
+						</MkFolder>
+
 						<MkFolder v-if="matchQuery([i18n.ts._role._options.canEditNote, 'canEditNote'])">
 							<template #label>{{ i18n.ts._role._options.canEditNote }}</template>
 							<template #suffix>{{ policies.canEditNote ? i18n.ts.yes : i18n.ts.no }}</template>

--- a/packages/frontend/src/pages/user/raw.vue
+++ b/packages/frontend/src/pages/user/raw.vue
@@ -12,9 +12,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<span :class="$style.userMInfoMetaName"><MkUserName :class="$style.userMInfoMetaName" :user="user"/></span>
 				<span :class="$style.userMInfoMetaSub"><span class="acct _monospace">@{{ acct(user) }}</span></span>
 				<span :class="$style.userMInfoMetaState">
-					<span v-if="suspended" :class="$style.suspended">Suspended</span>
-					<span v-if="silenced" :class="$style.silenced">Silenced</span>
 					<span v-if="moderator" :class="$style.moderator">Moderator</span>
+					<span v-if="silenced" :class="$style.silenced">Silenced</span>
+					<span v-if="limited" :class="$style.limited">Limited</span>
+					<span v-if="suspended" :class="$style.suspended">Suspended</span>
+					<span v-if="deleted" :class="$style.deleted">Deleted</span>
 				</span>
 			</div>
 		</div>
@@ -54,6 +56,8 @@ const props = defineProps<{
 const moderator = computed(() => props.user.isModerator ?? false);
 const silenced = computed(() => props.user.isSilenced ?? false);
 const suspended = computed(() => props.user.isSuspended ?? false);
+const limited = computed(() => props.user.isLimited ?? false);
+const deleted = computed(() => props.user.isDeleted ?? false);
 </script>
 
 <style lang="scss" module>
@@ -104,7 +108,9 @@ const suspended = computed(() => props.user.isSuspended ?? false);
 
 	> .suspended,
 	> .silenced,
-	> .moderator {
+	> .moderator
+	> .limited,
+	> .deleted {
 		display: inline-block;
 		border: solid 1px;
 		border-radius: 6px;
@@ -125,6 +131,16 @@ const suspended = computed(() => props.user.isSuspended ?? false);
 	> .moderator {
 		color: var(--MI_THEME-success);
 		border-color: var(--MI_THEME-success);
+	}
+
+	> .limited {
+		color: var(--error);
+		border-color: var(--error);
+	}
+
+	> .deleted {
+		color: var(--error);
+		border-color: var(--error);
 	}
 }
 </style>


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
アカウントを削除してもデータは保全されます。
モデレーター外はアカウントが削除されているような振舞い方をします。
ロールで論理削除あるいは物理削除を選べるようにします。

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
モデレーション強化

以下のPull Requestを引用
https://github.com/MisskeyIO/misskey/pull/532

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
