### PR TITLE
Fix : Drop&Fusionのランキングの取得範囲を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cherrypick",
-	"version": "4.15.1-misaki.4",
+	"version": "4.15.1-misaki.4a",
 	"basedMisskeyVersion": "2025.2.1",
 	"codename": "nasubi",
 	"repository": {

--- a/packages/backend/src/server/api/endpoints/bubble-game/ranking.ts
+++ b/packages/backend/src/server/api/endpoints/bubble-game/ranking.ts
@@ -46,7 +46,7 @@ export const paramDef = {
 	type: 'object',
 	properties: {
 		gameMode: { type: 'string' },
-		sinceHour: { type: 'integer', nullable: true, minimum: 0, maximum: 24 * 365 * 3 },
+		sinceHour: { type: 'integer', nullable: true, minimum: 1, maximum: 24 * 365 },
 	},
 	required: ['gameMode'],
 } as const;
@@ -67,7 +67,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					gameMode: ps.gameMode,
 					... (sinceHour > 0 ? {
 						seededAt: MoreThan(new Date(Date.now() - 1000 * 60 * 60 * sinceHour)),
-					} : {}),
+					} : {
+						seededAt: MoreThan(new Date(0)),
+					}),
 				},
 				order: {
 					score: 'DESC',

--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -52,11 +52,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 								<div style="width: auto; margin-left: auto; text-align: right;">
 									<MkSelect v-model="rankingSince" style="margin-left: 8px;">
 										<option value="1h">{{ getHourLocalize("1h") }}</option>
+										<option value="6h">{{ getHourLocalize("6h") }}</option>
 										<option value="24h">{{ getHourLocalize("24h") }}</option>
 										<option value="1w">{{ getHourLocalize("1w") }}</option>
 										<option value="30d">{{ getHourLocalize("30d") }}</option>
 										<option value="1y">{{ getHourLocalize("1y") }}</option>
-										<option value="all">{{ getHourLocalize("all") }}</option>
+										<!--<option value="all">{{ getHourLocalize("all") }}</option>-->
 									</MkSelect>
 								</div>
 							</div>
@@ -114,7 +115,7 @@ import MkSwitch from '@/components/MkSwitch.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 
 const gameMode = ref<'normal' | 'square' | 'yen' | 'sweets' | 'space'>('normal');
-const rankingSince = ref<'1h' | '24h' | '7d' | '30d' | '1y' | 'all'>('24h');
+const rankingSince = ref<'1h' | '6h' | '24h' | '7d' | '30d' | '1y' | 'all'>('7d');
 const gameStarted = ref(false);
 const mute = ref(false);
 const ranking = ref(null);

--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 										<option value="1h">{{ getHourLocalize("1h") }}</option>
 										<option value="6h">{{ getHourLocalize("6h") }}</option>
 										<option value="24h">{{ getHourLocalize("24h") }}</option>
-										<option value="1w">{{ getHourLocalize("1w") }}</option>
+										<option value="7d">{{ getHourLocalize("7d") }}</option>
 										<option value="30d">{{ getHourLocalize("30d") }}</option>
 										<option value="1y">{{ getHourLocalize("1y") }}</option>
 										<!--<option value="all">{{ getHourLocalize("all") }}</option>-->
@@ -115,7 +115,7 @@ import MkSwitch from '@/components/MkSwitch.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 
 const gameMode = ref<'normal' | 'square' | 'yen' | 'sweets' | 'space'>('normal');
-const rankingSince = ref<'1h' | '6h' | '24h' | '1w' | '30d' | '1y' | 'all'>('1w');
+const rankingSince = ref<'1h' | '6h' | '24h' | '7d' | '30d' | '1y' | 'all'>('7d');
 const gameStarted = ref(false);
 const mute = ref(false);
 const ranking = ref(null);

--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -115,7 +115,7 @@ import MkSwitch from '@/components/MkSwitch.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 
 const gameMode = ref<'normal' | 'square' | 'yen' | 'sweets' | 'space'>('normal');
-const rankingSince = ref<'1h' | '6h' | '24h' | '7d' | '30d' | '1y' | 'all'>('7d');
+const rankingSince = ref<'1h' | '6h' | '24h' | '1w' | '30d' | '1y' | 'all'>('1w');
 const gameStarted = ref(false);
 const mute = ref(false);
 const ranking = ref(null);


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
ランキングの全てにするとだいぶやばそうなので範囲制限した。
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
