### PR TITLE
Fix #21 : 物理削除済みのユーザーは除外するように

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cherrypick",
-	"version": "4.15.1-misaki.8",
+	"version": "4.15.1-misaki.8a",
 	"basedMisskeyVersion": "2025.2.1",
 	"codename": "nasubi",
 	"repository": {

--- a/packages/backend/src/server/api/endpoints/admin/get-users-from-ip.ts
+++ b/packages/backend/src/server/api/endpoints/admin/get-users-from-ip.ts
@@ -76,12 +76,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.limit(ps.limit)
 				.getMany();
 			const users = await this.userEntityService.packMany(results.map(r => r.userId), null);
-			return results.map(result => ({
-				id: result.userId,
-				ip: result.ip,
-				accessedAt: result.createdAt.toISOString(),
-				user: users.find(u => u.id === result.userId),
-			}));
+			return results
+				.map(result => ({
+					id: result.userId,
+					ip: result.ip,
+					accessedAt: result.createdAt.toISOString(),
+					user: users.find(u => u.id === result.userId),
+				}))
+				.filter(item => item.user !== undefined);
 		});
 	}
 }


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
物理削除済みのユーザーが含まれる場合フロントエンドでエラー吐くので
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
