### PR TITLE
Fix: 配送制限のノート表示UIの修正

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -38,9 +38,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-else-if="note.reactionAcceptance === 'likeOnly'" v-tooltip="i18n.ts.likeOnly" class="ti ti-heart"></i>
 			</span>
 			<span v-if="note.localOnly" style="margin-right: 0.5em;"><i v-tooltip="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
-			<span v-if="appearNote.deliveryTargets" v-tooltip="`${i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude']}\n${appearNote.deliveryTargets.hosts.join('\n')}`" style="margin-left: 0.5em;">
+			<span v-if="appearNote.deliveryTargets" v-tooltip="`${i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude']}\n${appearNote.deliveryTargets.hosts.join('\n')}`" style="margin-right: 0.5em;">
 				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
+			</span>
+			<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
+				<i class="ti ti-list-check"></i>
 			</span>
 			<span v-if="note.channel" style="margin-right: 0.5em;"><i v-tooltip="note.channel.name" class="ti ti-device-tv"></i></span>
 			<span :class="$style.renoteTime">

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -42,8 +42,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
 			</span>
-			<span v-else-if="appearNote.hasDeliveryTargets" v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
-				<i class="ti ti-list-check"></i>
+			<span v-else-if="appearNote.hasDeliveryTargets" style="margin-right: 0.5em;">
+				<i v-tooltip="i18n.ts.hasDeliveryTargets" class="ti ti-list-check"></i>
 			</span>
 			<span v-if="note.channel" style="margin-right: 0.5em;"><i v-tooltip="note.channel.name" class="ti ti-device-tv"></i></span>
 			<span :class="$style.renoteTime">

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -42,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
 			</span>
-			<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
+			<span v-if="appearNote.hasDeliveryTargets && !appearNote.deliveryTargets" v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
 				<i class="ti ti-list-check"></i>
 			</span>
 			<span v-if="note.channel" style="margin-right: 0.5em;"><i v-tooltip="note.channel.name" class="ti ti-device-tv"></i></span>

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -42,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
 			</span>
-			<span v-if="appearNote.hasDeliveryTargets && !appearNote.deliveryTargets" v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
+			<span v-else-if="appearNote.hasDeliveryTargets" v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
 				<i class="ti ti-list-check"></i>
 			</span>
 			<span v-if="note.channel" style="margin-right: 0.5em;"><i v-tooltip="note.channel.name" class="ti ti-device-tv"></i></span>

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -91,12 +91,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<i v-else-if="note.reactionAcceptance === 'nonSensitiveOnlyForLocalLikeOnlyForRemote'" v-tooltip="i18n.ts.nonSensitiveOnlyForLocalLikeOnlyForRemote" class="ti ti-heart-plus"></i>
 							<i v-else-if="note.reactionAcceptance === 'likeOnly'" v-tooltip="i18n.ts.likeOnly" class="ti ti-heart"></i>
 						</span>
-						<span v-if="appearNote.localOnly" style="margin-left: 0.5em;"><i v-tooltip="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
+						<span v-if="appearNote.localOnly" style="margin-left: 0.5em;"><i :title="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
 						<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :v-tooltip="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-left: 0.5em;">
 							<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 							<i v-else class="ti ti-list-details"></i>
 						</span>
-						<span v-if="appearNote.hasDeliveryTargets && !appearNote.deliveryTargets" :v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-left: 0.5em;">
+						<span v-if="appearNote.hasDeliveryTargets && !appearNote.deliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-left: 0.5em;">
 							<i class="ti ti-list-check"></i>
 						</span>
 					</div>

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -39,8 +39,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-else-if="note.reactionAcceptance === 'likeOnly'" v-tooltip="i18n.ts.likeOnly" class="ti ti-heart"></i>
 			</span>
 			<span v-if="note.localOnly" style="margin-right: 0.5em;"><i v-tooltip="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
-			<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :title="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-left: 0.5em;">	<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
+			<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :title="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-right: 0.5em;">
+				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
+			</span>
+			<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
+				<i class="ti ti-list-check"></i>
 			</span>
 			<span :class="$style.renoteTime">
 				<button ref="renoteTime" class="_button">
@@ -88,6 +92,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<i v-else-if="note.reactionAcceptance === 'likeOnly'" v-tooltip="i18n.ts.likeOnly" class="ti ti-heart"></i>
 						</span>
 						<span v-if="appearNote.localOnly" style="margin-left: 0.5em;"><i v-tooltip="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
+						<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :title="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-left: 0.5em;">
+							<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
+							<i v-else class="ti ti-list-details"></i>
+						</span>
+						<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-left: 0.5em;">
+							<i class="ti ti-list-check"></i>
+						</span>
 					</div>
 					<MkInstanceTicker v-if="showTicker" :host="appearNote.user.host" :instance="appearNote.user.instance" @click="showOnRemote"/>
 				</div>

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -43,7 +43,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 				<i v-else class="ti ti-list-details"></i>
 			</span>
-			<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
+			<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-right: 0.5em;">
 				<i class="ti ti-list-check"></i>
 			</span>
 			<span :class="$style.renoteTime">

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -92,11 +92,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<i v-else-if="note.reactionAcceptance === 'likeOnly'" v-tooltip="i18n.ts.likeOnly" class="ti ti-heart"></i>
 						</span>
 						<span v-if="appearNote.localOnly" style="margin-left: 0.5em;"><i v-tooltip="i18n.ts._visibility['disableFederation']" class="ti ti-rocket-off"></i></span>
-						<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :title="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-left: 0.5em;">
+						<span v-if="appearNote.deliveryTargets && (appearNote.deliveryTargets.mode === 'include' || appearNote.deliveryTargets.hosts?.length)" :v-tooltip="i18n.ts._deliveryTargetControl[appearNote.deliveryTargets.mode === 'include' ? 'deliveryTargetsInclude' : 'deliveryTargetsExclude'] + (appearNote.deliveryTargets.hosts?.length ? '\n' + appearNote.deliveryTargets.hosts.join('\n') : '')" style="margin-left: 0.5em;">
 							<i v-if="appearNote.deliveryTargets.mode === 'include'" class="ti ti-list-check"></i>
 							<i v-else class="ti ti-list-details"></i>
 						</span>
-						<span v-if="!appearNote.deliveryTargets && appearNote.hasDeliveryTargets" :title="i18n.ts.hasDeliveryTargets" style="margin-left: 0.5em;">
+						<span v-if="appearNote.hasDeliveryTargets && !appearNote.deliveryTargets" :v-tooltip="i18n.ts.hasDeliveryTargets" style="margin-left: 0.5em;">
 							<i class="ti ti-list-check"></i>
 						</span>
 					</div>


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
<img width="761" height="508" alt="image" src="https://github.com/user-attachments/assets/b0fb25b1-31a9-4557-b6f5-7a04538e15f8" />
自分やモデレーター持っていない場合でも配送制限されたか分かるように。
ノートの表示で反映されない問題の謎。

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
