### PR TITLE
feat: 絵文字リアクションのロール制御を追加

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -8885,6 +8885,32 @@ export interface Locale extends ILocale {
              * アカウントの整理の許可
              */
             "canTruncateAccount": string;
+            /**
+             * リアクション作成を許可する絵文字の種類
+             */
+            "reactionAvailability": string;
+            "_reactionAvailability": {
+                /**
+                 * すべて許可
+                 */
+                "all": string;
+                /**
+                 * センシティブ除く絵文字を許可
+                 */
+                "nonSensitiveOnly": string;
+                /**
+                 * Unicode絵文字のみを許可
+                 */
+                "unicodeOnly": string;
+                /**
+                 * ハート絵文字のみを許可
+                 */
+                "heartOnly": string;
+                /**
+                 * すべて拒否
+                 */
+                "deny": string;
+            };
         };
         "_condition": {
             /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2297,6 +2297,13 @@ _role:
     canSetFederationAvatarShape: "アイコンの形設定の連合を許可"
     canDeleteAccount: "アカウントの削除の許可"
     canTruncateAccount: "アカウントの整理の許可"
+    reactionAvailability: "リアクション作成を許可する絵文字の種類"
+    _reactionAvailability:
+      all: "すべて許可"
+      nonSensitiveOnly: "センシティブ除く絵文字を許可"
+      unicodeOnly: "Unicode絵文字のみを許可"
+      heartOnly: "ハート絵文字のみを許可"
+      deny: "すべて拒否"
   _condition:
     roleAssignedTo: "マニュアルロールにアサイン済み"
     isLocal: "ローカルユーザー"

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -122,6 +122,13 @@ export class ReactionService {
 			throw new IdentifiableError('12c35529-3c79-4327-b1cc-e2cf63a71925', 'You cannot react to Renote.');
 		}
 
+		// Check if user can react
+		const policy = await this.getReactionAvailability(user.id);
+
+		if (policy === 'deny') {
+			throw new Error('ROLE_PERMISSION_DENIED');
+		}
+
 		let reaction = _reaction ?? FALLBACK;
 
 		if (note.reactionAcceptance === 'likeOnly' || ((note.reactionAcceptance === 'likeOnlyForRemote' || note.reactionAcceptance === 'nonSensitiveOnlyForLocalLikeOnlyForRemote') && (user.host != null))) {
@@ -148,6 +155,11 @@ export class ReactionService {
 							reaction = FALLBACK;
 						}
 
+						// ポリシー
+						if (policy === 'nonSensitiveOnly' && emoji.isSensitive) {
+							reaction = FALLBACK;
+						}
+
 						// for media silenced host, custom emoji reactions are not allowed
 						if (reacterHost != null && this.utilityService.isMediaSilencedHost(this.meta.mediaSilencedHosts, reacterHost)) {
 							reaction = FALLBACK;
@@ -159,8 +171,22 @@ export class ReactionService {
 				} else {
 					reaction = FALLBACK;
 				}
+				// カスタム絵文字を使用する権限がない場合
+				if (policy === 'unicodeOnly') {
+					reaction = FALLBACK;
+				}
 			} else {
 				reaction = this.normalize(reaction);
+
+				if (reaction === '🖕' && policy !== 'all') {
+					// 中指はall権限がないと使えない
+					reaction = FALLBACK;
+				}
+
+				// ハート以外のリアクションを使用する権限がない場合
+				if (policy === 'heartOnly') {
+					reaction = FALLBACK;
+				}
 			}
 		}
 
@@ -419,5 +445,11 @@ export class ReactionService {
 			name: undefined,
 			host: undefined,
 		};
+	}
+
+	@bindThis
+	public async getReactionAvailability(userId: MiUser['id']): Promise<'all' | 'nonSensitiveOnly' | 'unicodeOnly' | 'heartOnly' | 'deny'> {
+		const policies = await this.roleService.getUserPolicies(userId);
+		return policies.reactionAvailability;
 	}
 }

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -84,6 +84,7 @@ export type RolePolicies = {
 	canSetFederationAvatarShape: boolean;
 	canDeleteAccount: boolean;
 	canTruncateAccount: boolean;
+	reactionAvailability: 'all' | 'nonSensitiveOnly' | 'unicodeOnly' | 'heartOnly' | 'deny';
 };
 
 export const DEFAULT_POLICIES: RolePolicies = {
@@ -137,6 +138,7 @@ export const DEFAULT_POLICIES: RolePolicies = {
 	canSetFederationAvatarShape: true,
 	canDeleteAccount: true,
 	canTruncateAccount: true,
+	reactionAvailability: 'all',
 };
 
 @Injectable()
@@ -701,6 +703,15 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			return 'unavailable';
 		}
 
+		function aggregateReactionAvailability(vs: RolePolicies['reactionAvailability'][]) {
+			if (vs.some(v => v === 'deny')) return 'deny';
+			if (vs.some(v => v === 'heartOnly')) return 'heartOnly';
+			if (vs.some(v => v === 'unicodeOnly')) return 'unicodeOnly';
+			if (vs.some(v => v === 'nonSensitiveOnly')) return 'nonSensitiveOnly';
+			if (vs.some(v => v === 'all')) return 'all';
+			return 'deny';
+		}
+
 		return {
 			gtlAvailable: calc('gtlAvailable', vs => vs.some(v => v === true)),
 			ltlAvailable: calc('ltlAvailable', vs => vs.some(v => v === true)),
@@ -752,6 +763,7 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			canSetFederationAvatarShape: calc('canSetFederationAvatarShape', vs => vs.some(v => v === true)),
 			canDeleteAccount: calc('canDeleteAccount', vs => vs.some(v => v === true)),
 			canTruncateAccount: calc('canTruncateAccount', vs => vs.some(v => v === true)),
+			reactionAvailability: calc('reactionAvailability', aggregateReactionAvailability),
 		};
 	}
 

--- a/packages/backend/src/models/json-schema/role.ts
+++ b/packages/backend/src/models/json-schema/role.ts
@@ -370,6 +370,12 @@ export const packedRolePoliciesSchema = {
 			optional: false, nullable: false,
 			enum: ['available', 'readonly', 'unavailable'],
 		},
+
+		reactionAvailability: {
+			type: 'string',
+			optional: false, nullable: false,
+			enum: ['all', 'nonSensitiveOnly', 'unicodeOnly', 'heartOnly', 'deny'],
+		},
 	},
 } as const;
 

--- a/packages/cherrypick-js/src/autogen/types.ts
+++ b/packages/cherrypick-js/src/autogen/types.ts
@@ -5725,6 +5725,8 @@ export type components = {
 			canTruncateAccount: boolean,
       /** @enum {string} */
       chatAvailability: 'available' | 'readonly' | 'unavailable';
+			/** @enum {string} */
+			reactionAvailability: 'all' | 'nonSensitiveOnly' | 'unicodeOnly' | 'heartOnly' | 'deny';
     };
     ReversiGameLite: {
       /** Format: id */

--- a/packages/frontend-shared/js/const.ts
+++ b/packages/frontend-shared/js/const.ts
@@ -129,6 +129,7 @@ export const ROLE_POLICIES = [
 	'canSetFederationAvatarShape',
 	'canDeleteAccount',
 	'canTruncateAccount',
+	'reactionAvailability',
 ] as const;
 
 export const MFM_TAGS = ['tada', 'jelly', 'twitch', 'shake', 'spin', 'jump', 'bounce', 'flip', 'x2', 'x3', 'x4', 'scale', 'position', 'fg', 'bg', 'border', 'font', 'blur', 'rainbow', 'sparkle', 'fade', 'rotate', 'ruby', 'unixtime'];

--- a/packages/frontend/src/pages/admin/roles.editor.vue
+++ b/packages/frontend/src/pages/admin/roles.editor.vue
@@ -397,6 +397,44 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</div>
 			</MkFolder>
 
+			<MkFolder v-if="matchQuery([i18n.ts._role._options.reactionAvailability, 'reactionAvailability'])">
+				<template #label>{{ i18n.ts._role._options.reactionAvailability }}</template>
+				<template #suffix>
+					<span v-if="role.target!=='manualLevel' && role.policies.reactionAvailability.useDefault" :class="$style.useDefaultLabel">{{ i18n.ts._role.useBaseValue }}</span>
+					<span v-else-if="role.target!=='manualLevel'">{{ role.policies.reactionAvailability ? i18n.ts._role._options._reactionAvailability[role.policies.reactionAvailability.value] : "unknown" }}</span>
+					<span v-else-if="role.target === 'manualLevel' && isPolicyLevelDefault('reactionAvailability')">{{ i18n.ts._role.useBaseValue }}</span>
+					<span v-else>{{ i18n.tsx._role.countOfCondLevelPolicies({value:levelCondPolicies.reactionAvailability.CondFormula.length}) }}</span>
+					<span :class="$style.priorityIndicator"><i :class="getPriorityIcon(role.policies.reactionAvailability)"></i></span>
+				</template>
+				<div class="_gaps">
+					<div v-if="role.target === 'manualLevel'">
+						<RolesEditorLevelCond v-model="levelCondPolicies.reactionAvailability" :readonly="readonly">
+							<option value="all">{{ i18n.ts._role._options._reactionAvailability.all }}</option>
+							<option value="nonSensitiveOnly">{{ i18n.ts._role._options._reactionAvailability.nonSensitiveOnly }}</option>
+							<option value="unicodeOnly">{{ i18n.ts._role._options._reactionAvailability.unicodeOnly }}</option>
+							<option value="heartOnly">{{ i18n.ts._role._options._reactionAvailability.heartOnly }}</option>
+							<option value="deny">{{ i18n.ts._role._options._reactionAvailability.deny }}</option>
+						</RolesEditorLevelCond>
+					</div>
+					<div v-else class="_gaps">
+						<MkSwitch v-model="role.policies.reactionAvailability.useDefault" :readonly="readonly">
+							<template #label>{{ i18n.ts._role.useBaseValue }}</template>
+						</MkSwitch>
+						<MkSelect v-model="role.policies.reactionAvailability.value" :disabled="role.policies.reactionAvailability.useDefault" :readonly="readonly">
+							<template #label>{{ i18n.ts.enable }}</template>
+							<option value="all">{{ i18n.ts._role._options._reactionAvailability.all }}</option>
+							<option value="nonSensitiveOnly">{{ i18n.ts._role._options._reactionAvailability.nonSensitiveOnly }}</option>
+							<option value="unicodeOnly">{{ i18n.ts._role._options._reactionAvailability.unicodeOnly }}</option>
+							<option value="heartOnly">{{ i18n.ts._role._options._reactionAvailability.heartOnly }}</option>
+							<option value="deny">{{ i18n.ts._role._options._reactionAvailability.deny }}</option>
+						</MkSelect>
+					</div>
+					<MkRange v-model="role.policies.reactionAvailability.priority" :min="0" :max="2" :step="1" easing :textConverter="(v) => v === 0 ? i18n.ts._role._priority.low : v === 1 ? i18n.ts._role._priority.middle : v === 2 ? i18n.ts._role._priority.high : ''">
+						<template #label>{{ i18n.ts._role.priority }}</template>
+					</MkRange>
+				</div>
+			</MkFolder>
+
 			<MkFolder v-if="matchQuery([i18n.ts._role._options.canPurgeAccount, 'canPurgeAccount'])">
 				<template #label>{{ i18n.ts._role._options.canPurgeAccount }}</template>
 				<template #suffix>

--- a/packages/frontend/src/pages/admin/roles.vue
+++ b/packages/frontend/src/pages/admin/roles.vue
@@ -111,6 +111,19 @@ SPDX-License-Identifier: AGPL-3.0-only
 						</MkSwitch>
 					</MkFolder>
 
+					<MkFolder v-if="matchQuery([i18n.ts._role._options.reactionAvailability, 'reactionAvailability'])">
+						<template #label>{{ i18n.ts._role._options.reactionAvailability }}</template>
+						<template #suffix>{{ policies.reactionAvailability ? i18n.ts._role._options._reactionAvailability[policies.reactionAvailability] : "unknown" }}</template>
+						<MkSelect v-model="policies.reactionAvailability">
+							<template #label>{{ i18n.ts.enable }}</template>
+							<option value="all">{{ i18n.ts._role._options._reactionAvailability.all }}</option>
+							<option value="nonSensitiveOnly">{{ i18n.ts._role._options._reactionAvailability.nonSensitiveOnly }}</option>
+							<option value="unicodeOnly">{{ i18n.ts._role._options._reactionAvailability.unicodeOnly }}</option>
+							<option value="heartOnly">{{ i18n.ts._role._options._reactionAvailability.heartOnly }}</option>
+							<option value="deny">{{ i18n.ts._role._options._reactionAvailability.deny }}</option>
+						</MkSelect>
+					</MkFolder>
+
 					<MkFolder v-if="matchQuery([i18n.ts._role._options.canPurgeAccount, 'canPurgeAccount'])">
 						<template #label>{{ i18n.ts._role._options.canPurgeAccount }}</template>
 						<template #suffix>{{ policies.canPurgeAccount ? i18n.ts.yes : i18n.ts.no }}</template>


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
<!-- 이 PR은 무엇을 변경하며, 어떻게 달라집니까? -->
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
リアクションできる種類にロール制御を追加
５つの権限から設定可能
「すべて」「センシティブを除く(🖕を含む)」「Unicode絵文字のみ」「ハートのみ」「すべて拒否」

## Why
<!-- 왜 그렇게 변경했나요? 어떤 의도인가요? 문제는 무엇인가요? -->
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
モデレーション(スパムのように中指関連のリアクションを送信していたユーザーがいたため)

## Additional info (optional)
<!-- 테스트 관점 등 -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ある程度の動作は確認済み

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
